### PR TITLE
erlaudio can't find NIF when dependency of an elixir project

### DIFF
--- a/src/erlaudio_drv.erl
+++ b/src/erlaudio_drv.erl
@@ -60,7 +60,7 @@ nif_stub_error(Line) ->
 -endif.
 
 init() ->
-  PrivDir = case code:priv_dir(?MODULE) of
+  PrivDir = case code:priv_dir(erlaudio) of
     {error, bad_name} ->
       try escript:script_name() of
         Filename ->


### PR DESCRIPTION
## Steps to reproduce
1. Create new elixir project (I'm using 1.0.5)
2. Add `{:erlaudio, "~> 0.2.3"}` as a dependency in `mix.exs`
3. `mix deps.get`
4. `mix deps.compile`
5. `iex -S mix`
6. `:erlaudio.devices`
## Error message

```
** (UndefinedFunctionError) undefined function: :erlaudio_drv.get_device_count/0 (module :erlaudio_drv is not available)

00:58:41.157 [warn]  The on_load function for module erlaudio_drv returned {:error,
 {:load_failed,
  'Failed to load NIF library: \'dlopen(./priv/erlaudio_drv.so, 2): image not found\''}}

    (erlaudio) :erlaudio_drv.get_device_count()
    (erlaudio) src/erlaudio.erl:70: :erlaudio.devices/0
```
## Steps to confirm not issue of erlaudio alone
1. `cd deps/erlaudio`
2. `iex -S mix`
3. `:erlaudio.devices`

Produces something like

```
iex(1)> :erlaudio.devices
[{:erlaudio_device, 0, "AirPlay", 0, 0, 2, 0.01, 0.2014512471655329, 0.1,
  0.21160997732426304, 4.41e4},
 {:erlaudio_device, 1, "Built-in Microph", 0, 2, 0, 0.002993197278911565, 0.01,
  0.013151927437641724, 0.1, 4.41e4},
 {:erlaudio_device, 2, "Built-in Output", 0, 0, 2, 0.01, 0.013582766439909298,
  0.1, 0.023741496598639455, 4.41e4}]
```
## Possible causes
1. Attempting to locate the `:code.priv_dir` of the `erlaudio_drv` module instead of the `erlaudio` module since default location for the `erlaudio_drv.so` seems to be `deps/erlaudio/priv/erlaudio_drv.so`; however, as indicated by the error message above, it's attempting to load from `priv/erlaudio_drv.so` for the application, not the dependency.
## Possible workarounds
1. This pull request which looks for erlaudio_drv.so in the priv_dir of erlaudio explicitly rather than erlaudio_drv
